### PR TITLE
prompt for build process after menuconfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,9 @@ impl KernelBuilder {
 
         if cli.menuconfig {
             Self::make_menuconfig(path)?;
+            if !Self::confirm_prompt("Continue build process?")? {
+                return Ok(());
+            }
         }
 
         if !cli.no_build {


### PR DESCRIPTION
When exiting the `menuconfig` the builder is prompting to continue the build process, so the user can exit early if he only wanted to open the `menuconfig` for a specific kernel version.